### PR TITLE
revert(sptr): Use strict provenance (stable since 1.84)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,6 @@ dependencies = [
  "criterion",
  "replace_with",
  "rustc_version",
- "sptr",
  "typeid",
 ]
 
@@ -346,12 +345,6 @@ dependencies = [
  "ryu",
  "serde",
 ]
-
-[[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2021"
 links = "rustlithium"  # Force uniqueness of crate version
 
 [dependencies]
-sptr = "0.3.2"
 typeid = "1.0.2"
 
 [dev-dependencies]

--- a/src/heterogeneous_stack/array.rs
+++ b/src/heterogeneous_stack/array.rs
@@ -2,12 +2,6 @@ use super::align::assert_aligned;
 use core::cell::{Cell, UnsafeCell};
 use core::mem::MaybeUninit;
 
-#[allow(
-    unused_imports,
-    reason = "XXX: remove when strict provenance is stabilized"
-)]
-use sptr::Strict;
-
 /// A thread-unsafe array-backed stack allocator.
 ///
 /// This allocator can allocate values with sizes that are multiples of `align_of::<AlignAs>()`,
@@ -55,9 +49,7 @@ impl<AlignAs, const CAPACITY: usize> Stack<AlignAs, CAPACITY> {
         if n == 0 {
             // Dangling pointers to ZSTs are always valid and unique. Creating `*mut AlignAs`
             // instead of *mut u8` forces alignment.
-            // XXX: Replace with `return Some(core::ptr::dangling_mut::<AlignAs>().cast());` when
-            // strict provenance is stabilized
-            return Some(align_of::<AlignAs>() as *mut u8);
+            return Some(core::ptr::dangling_mut::<AlignAs>().cast());
         }
 
         // SAFETY: len <= CAPACITY is an invariant

--- a/src/heterogeneous_stack/heap.rs
+++ b/src/heterogeneous_stack/heap.rs
@@ -3,12 +3,6 @@ use alloc::alloc;
 use core::alloc::Layout;
 use core::marker::PhantomData;
 
-#[allow(
-    unused_imports,
-    reason = "XXX: remove when strict provenance is stabilized"
-)]
-use sptr::Strict;
-
 /// A heap-backed allocator.
 ///
 /// This allocator can allocate values with sizes that are multiples of `align_of::<AlignAs>()`,

--- a/src/heterogeneous_stack/unbounded.rs
+++ b/src/heterogeneous_stack/unbounded.rs
@@ -1,11 +1,5 @@
 use super::{align::assert_aligned, array::Stack as BoundedStack, heap::Heap};
 
-#[allow(
-    unused_imports,
-    reason = "XXX: remove when strict provenance is stabilized"
-)]
-use sptr::Strict;
-
 /// A thread-unsafe heterogeneous stack, using statically allocated space when possible.
 ///
 /// Although the stack doesn't track runtime types, all elements are considered independent. Stack

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,10 +157,6 @@
     clippy::inline_always,
     reason = "I'm not an idiot, this is a result of benchmarking/profiling"
 )]
-#![allow(
-    unstable_name_collisions,
-    reason = "XXX: remove when strict provenance is stabilized"
-)]
 
 #[cfg(panic = "abort")]
 compile_error!("Using Lithium with panic = \"abort\" is unsupported");


### PR DESCRIPTION
This reverts commit aded19bea657e535db2f47b9fe23314a5a2020c9.